### PR TITLE
fix: Refactor version bump workflows for improved automation

### DIFF
--- a/.github/workflows/bump-candidate.yaml
+++ b/.github/workflows/bump-candidate.yaml
@@ -56,9 +56,16 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
 
+      - name: Create working branch
+        run: git checkout -b version-bump-rc-work
+
       - name: Bump Versions with Lerna
         run: |
           npx lerna version --conventional-prerelease --preid=rc --no-push --no-git-tag-version --yes
+
+      - name: Convert Lerna commit to staged changes
+        run: |
+          git reset --soft HEAD~1 || true
 
       - name: Build Packages
         run: yarn build
@@ -66,17 +73,7 @@ jobs:
       - name: Format Code with Prettier
         run: yarn format
 
-      - name: Check for Changes
-        id: check_changes
-        run: |
-          if git diff --quiet && git diff --cached --quiet; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-          else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Create or Update Pull Request
-        if: steps.check_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: "chore: bump versions for release candidate [skip ci]"

--- a/.github/workflows/bump-main.yaml
+++ b/.github/workflows/bump-main.yaml
@@ -66,30 +66,46 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
 
+      - name: Create working branch
+        run: git checkout -b version-bump-main-work
+
+      - name: Detect current and target version
+        id: version_meta
+        run: |
+          CURRENT=$(node -p "require('./lerna.json').version")
+          if [[ "$CURRENT" == *"-rc."* ]]; then
+            TARGET=${CURRENT%%-rc.*}
+            echo "Detected release candidate version $CURRENT -> target $TARGET"
+            echo "target=$TARGET" >> $GITHUB_OUTPUT
+          else
+            echo "No release candidate suffix detected (current=$CURRENT)"
+            echo "target=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Bump Versions with Lerna
         run: |
           if [ "${{ inputs.bump-type }}" = "auto" ] || [ -z "${{ inputs.bump-type }}" ]; then
-            # Graduate release candidates or use conventional commits
-            npx lerna version --conventional-graduate --no-push --no-git-tag-version --yes
+            if [ -n "${{ steps.version_meta.outputs.target }}" ]; then
+              echo "Graduating pre-release to ${{ steps.version_meta.outputs.target }}"
+              npx lerna version ${{ steps.version_meta.outputs.target }} --force-publish --no-push --no-git-tag-version --yes
+            elif git tag --list 'v*' | grep -q .; then
+              npx lerna version --conventional-graduate --no-push --no-git-tag-version --yes
+            else
+              npx lerna version --conventional-commits --no-push --no-git-tag-version --yes
+            fi
           else
             # Use specified bump type
             npx lerna version ${{ inputs.bump-type }} --no-push --no-git-tag-version --yes
           fi
 
+      - name: Convert Lerna commit to staged changes
+        run: |
+          git reset --soft HEAD~1 || true
+
       - name: Build Packages
         run: yarn build
 
-      - name: Check for Changes
-        id: check_changes
-        run: |
-          if git diff --quiet && git diff --cached --quiet; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-          else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Create or Update Pull Request
-        if: steps.check_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: "chore: bump versions for release [skip ci]"


### PR DESCRIPTION
Updated bump-candidate and bump-main GitHub Actions workflows to create dedicated working branches, convert Lerna commits to staged changes, and remove redundant change checks. The main workflow now detects and graduates release candidate versions more robustly, improving automation and reliability of version bump PRs.