### PR TITLE
fix: Enhance version bump workflow for release candidates

### DIFF
--- a/.github/workflows/bump-main.yaml
+++ b/.github/workflows/bump-main.yaml
@@ -66,20 +66,61 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
 
+      - name: Create working branch
+        run: git checkout -b version-bump-main-work
+
+      - name: Detect current and target version
+        id: version_meta
+        run: |
+          CURRENT=$(node -p "require('./lerna.json').version")
+          if [[ "$CURRENT" == *"-rc."* ]]; then
+            TARGET=${CURRENT%%-rc.*}
+            echo "Detected release candidate version $CURRENT -> target $TARGET"
+            echo "target=$TARGET" >> $GITHUB_OUTPUT
+          else
+            echo "No release candidate suffix detected (current=$CURRENT)"
+            echo "target=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Decide if bump is required
+        id: bump_control
+        run: |
+          if [ "${{ inputs.bump-type }}" != "auto" ] && [ -n "${{ inputs.bump-type }}" ]; then
+            echo "Manual bump requested (${{ inputs.bump-type }})"
+            echo "should=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if [ -n "${{ steps.version_meta.outputs.target }}" ]; then
+            echo "Graduating release candidate to ${{ steps.version_meta.outputs.target }}"
+            echo "should=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "No bump required (auto mode with stable version)"
+          echo "should=false" >> $GITHUB_OUTPUT
+
       - name: Bump Versions with Lerna
+        if: ${{ steps.bump_control.outputs.should == 'true' }}
         run: |
           if [ "${{ inputs.bump-type }}" = "auto" ] || [ -z "${{ inputs.bump-type }}" ]; then
-            # Graduate release candidates or use conventional commits
-            npx lerna version --conventional-graduate --no-push --no-git-tag-version --yes
+            if [ -n "${{ steps.version_meta.outputs.target }}" ]; then
+              npx lerna version ${{ steps.version_meta.outputs.target }} --force-publish --no-push --no-git-tag-version --yes
+            else
+              npx lerna version --conventional-commits --force-publish --no-push --no-git-tag-version --yes
+            fi
           else
-            # Use specified bump type
             npx lerna version ${{ inputs.bump-type }} --no-push --no-git-tag-version --yes
           fi
 
+      - name: Convert Lerna commit to staged changes
+        if: ${{ steps.bump_control.outputs.should == 'true' }}
+        run: git reset --soft HEAD~1 || true
+
       - name: Build Packages
+        if: ${{ steps.bump_control.outputs.should == 'true' }}
         run: yarn build
 
       - name: Check for Changes
+        if: ${{ steps.bump_control.outputs.should == 'true' }}
         id: check_changes
         run: |
           if git diff --quiet && git diff --cached --quiet; then
@@ -89,7 +130,7 @@ jobs:
           fi
 
       - name: Create or Update Pull Request
-        if: steps.check_changes.outputs.has_changes == 'true'
+        if: ${{ steps.bump_control.outputs.should == 'true' && steps.check_changes.outputs.has_changes == 'true' }}
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: "chore: bump versions for release [skip ci]"


### PR DESCRIPTION
Adds logic to detect and graduate release candidate versions, creates a working branch, and improves control over when version bumps occur. The workflow now distinguishes between manual and automatic bumps, and only proceeds with versioning and PR creation when necessary.