### PR TITLE
fix: Remove environment settings from bump workflows

### DIFF
--- a/.github/workflows/bump-candidate.yaml
+++ b/.github/workflows/bump-candidate.yaml
@@ -33,7 +33,6 @@ jobs:
       )
 
     runs-on: ubuntu-latest
-    environment: Development
 
     steps:
       - name: Checkout code
@@ -56,8 +55,8 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
 
-      - name: Create working branch
-        run: git checkout -b version-bump-rc-work
+      - name: Ensure working tree is on candidate
+        run: git checkout candidate
 
       - name: Bump Versions with Lerna
         run: |

--- a/.github/workflows/bump-main.yaml
+++ b/.github/workflows/bump-main.yaml
@@ -41,10 +41,7 @@ jobs:
           !contains(github.event.head_commit.message, 'chore: bump versions')
         )
       )
-
     runs-on: ubuntu-latest
-    environment: Production
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Eliminated the 'environment' field from both bump-candidate and bump-main GitHub Actions workflows. Also updated the candidate workflow to check out the 'candidate' branch directly instead of creating a new working branch.