### PR TITLE
Specify branch ref in bump workflow checkouts

### DIFF
--- a/.github/workflows/bump-candidate.yaml
+++ b/.github/workflows/bump-candidate.yaml
@@ -38,6 +38,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: candidate
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump-main.yaml
+++ b/.github/workflows/bump-main.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added explicit 'ref' parameters to the checkout steps in bump-candidate and bump-main workflows to ensure the correct branches are checked out during workflow execution.