### PR TITLE
Specify branch ref in publish workflows

### DIFF
--- a/.github/workflows/publish-candidate.yaml
+++ b/.github/workflows/publish-candidate.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
+          ref: candidate
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/publish-main.yaml
+++ b/.github/workflows/publish-main.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
           fetch-tags: true
 


### PR DESCRIPTION
Added explicit 'ref' parameters to the checkout steps in both publish-candidate and publish-main GitHub Actions workflows to ensure the correct branch is checked out during workflow execution.