### PR TITLE
fix: Fix orientation detection for square images

### DIFF
--- a/packages/core/src/components/lf-canvas/handlers.canvas.ts
+++ b/packages/core/src/components/lf-canvas/handlers.canvas.ts
@@ -136,7 +136,7 @@ export const prepCanvasHandlers = (
           if (image instanceof HTMLImageElement) {
             const { naturalWidth, naturalHeight } = image;
             const orientation: LfCanvasOrientation =
-              naturalWidth >= naturalHeight ? "landscape" : "portrait";
+              naturalWidth > naturalHeight ? "landscape" : "portrait";
 
             set.orientation(orientation);
           } else if (image instanceof SVGElement) {


### PR DESCRIPTION
Changed the orientation logic to classify images with equal width and height as 'portrait' instead of 'landscape'.