### PR TITLE
fix: Return selected IDs from setSelection

### DIFF
--- a/packages/core/src/components/lf-tree/state.selection.ts
+++ b/packages/core/src/components/lf-tree/state.selection.ts
@@ -58,25 +58,27 @@ export const createSelectionState = (
       return clearSelection(options);
     }
 
-    return sync.applyIdsWithSanitization(ids, options, (sanitized, opts) => {
+    let finalIds: string[] = [];
+
+    sync.applyIdsWithSanitization(ids, options, (sanitized, opts) => {
       const framework = controller.get.manager;
       const dataset = controller.get.dataset();
 
-      // If framework exists and dataset is available, apply full sanitization with predicates
       if (framework && dataset) {
         const result = framework.data.node.sanitizeIds(dataset, sanitized, {
           predicate: (node: LfDataNode) => controller.get.canSelectNode(node),
           limit: controller.get.allowsMultiSelect() ? undefined : 1,
         });
-        commit(result.ids, result.nodes, opts);
+        finalIds = commit(result.ids, result.nodes, opts);
       } else {
-        // Framework or dataset not ready - commit pending IDs (already stored by synchronizer)
         const pendingIds = controller.get.allowsMultiSelect()
           ? sanitized
           : sanitized.slice(0, 1);
-        commit(pendingIds, [], opts);
+        finalIds = commit(pendingIds, [], opts);
       }
     });
+
+    return finalIds;
   };
   //#endregion
 


### PR DESCRIPTION
Modified the setSelection function to return the final selected IDs after applying sanitization and committing. This allows consumers to access the resulting selection directly.