### PR TITLE
ci: Exclude version-bump commits from bump workflows

### DIFF
--- a/.github/workflows/bump-candidate.yaml
+++ b/.github/workflows/bump-candidate.yaml
@@ -27,7 +27,8 @@ jobs:
         !github.event.head_commit ||
         (
           !contains(github.event.head_commit.message, '[skip bump]') &&
-          !contains(github.event.head_commit.message, 'chore: bump versions')
+          !contains(github.event.head_commit.message, 'chore: bump versions') &&
+          !contains(github.event.head_commit.message, 'version-bump-rc')
         )
       )
 

--- a/.github/workflows/bump-main.yaml
+++ b/.github/workflows/bump-main.yaml
@@ -37,7 +37,8 @@ jobs:
         !github.event.head_commit ||
         (
           !contains(github.event.head_commit.message, '[skip bump]') &&
-          !contains(github.event.head_commit.message, 'chore: bump versions')
+          !contains(github.event.head_commit.message, 'chore: bump versions') &&
+          !contains(github.event.head_commit.message, 'version-bump-main')
         )
       )
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updated bump-candidate and bump-main GitHub Actions to skip execution when commit messages contain 'version-bump-rc' or 'version-bump-main', preventing unnecessary workflow runs for automated version bump commits.